### PR TITLE
Improving the cleaning step

### DIFF
--- a/clean_gnome.arch.sh
+++ b/clean_gnome.arch.sh
@@ -2,10 +2,12 @@
 
 # removing not needed packages
 sudo pacman -R yelp gnome-calendar gnome-logs gnome-weather gnome-user-share gnome-user-docs gnome-system-monitor gnome-software gnome-remote-desktop gnome-photos gnome-maps gnome-getting-started-docs gnome-font-viewer gnome-documents gnome-contacts gnome-clocks gnome-characters gnome-boxes gnome-books gnome-backgrounds epiphany
-# cleaning up (runs 5 times)
-for _ in {1...5}
+
+# cleaning up
+while [ ! "$(pacman -Qdtq)" ]
 do
-sudo pacman -Rsn $(pacman -Qdtq)
+    sudo pacman -Rsn "$(pacman -Qdtq)"
 done
+
 # reinstalling fuse2
 sudo pacman -S --needed fuse2


### PR DESCRIPTION
Running the cleaning step 5 times seemed a bit arbitrary, so I replaced it with a loop that continues until there are no true orphan packages left. Just to be sure I run `shellcheck` and everything seems fine